### PR TITLE
adapt to sanic@0.5.4

### DIFF
--- a/sanic_limiter/extension.py
+++ b/sanic_limiter/extension.py
@@ -151,7 +151,7 @@ class Limiter(object):
         return self._limiter
 
     def __check_request_limit(self, request):
-        endpoint = request.url or ""
+        endpoint = request.path or ""
         view_handler = self.app.router.routes_static.get(endpoint, None)
         if view_handler is None:
             return


### PR DESCRIPTION
lastest sanic in pip is 0.5.4
`request.url` with host, so it will not match anything in `app.router.routes_static`
change to use `request.path`