### PR TITLE
Fix IP keyfunc for reverse proxies

### DIFF
--- a/sanic_limiter/util.py
+++ b/sanic_limiter/util.py
@@ -8,4 +8,4 @@ def get_remote_address(request):
     :param: request: request object of sanic
     :return: the ip address of given request (or 127.0.0.1 if none found)
     """
-    return request.ip[0] or '127.0.0.1'
+    return request.remote_addr or request.ip


### PR DESCRIPTION
I was noticing in my logs a bunch of single digit IP addresses when I was logging them and found this function to be the culprit.

`request.ip[0]` was the first digit of the localhost while `remote_addr` was the actual incoming IP (when running my server w/ a reverse proxy in nginx). 