### PR TITLE
move the initialization of self.app into init_app

### DIFF
--- a/sanic_limiter/extension.py
+++ b/sanic_limiter/extension.py
@@ -77,7 +77,6 @@ class Limiter(object):
                  , storage_options={}
                  , swallow_errors=False
                  ):
-        self.app = app
         self.logger = logging.getLogger("sanic-limiter")
 
         self.enabled = True
@@ -117,6 +116,7 @@ class Limiter(object):
         """
         :param app: :class:`sanic.Sanic` instance to rate limit.
         """
+        self.app = app
         self.enabled = app.config.setdefault(C.ENABLED, True)
         self._swallow_errors = app.config.setdefault(
             C.SWALLOW_ERRORS, self._swallow_errors


### PR DESCRIPTION
Prior to this change `self.app` was only initialized in `__init__`. This caused the extension to fail when adding the app via `init_app(app)` because `self.app` is required for https://github.com/bohea/sanic-limiter/blob/master/sanic_limiter/extension.py#L155