### PR TITLE
Cgoosen sanic 19.6.3 fix

### DIFF
--- a/sanic_limiter/util.py
+++ b/sanic_limiter/util.py
@@ -12,8 +12,5 @@ def get_remote_address(request):
     # Seems to break on sanic 19.6.3
     if hasattr(request, 'remote_addr'):
         return request.remote_addr
-    elif hasattr(request, '_remote_addr'):
-        return request._remote_addr
-        # return reque
     else:
         return request.ip

--- a/sanic_limiter/util.py
+++ b/sanic_limiter/util.py
@@ -8,4 +8,12 @@ def get_remote_address(request):
     :param: request: request object of sanic
     :return: the ip address of given request (or 127.0.0.1 if none found)
     """
-    return request.remote_addr or request.ip
+    # Check if request object has remote_addr attribute set
+    # Seems to break on sanic 19.6.3
+    if hasattr(request, 'remote_addr'):
+        return request.remote_addr
+    elif hasattr(request, '_remote_addr'):
+        return request._remote_addr
+        # return reque
+    else:
+        return request.ip


### PR DESCRIPTION
Not sure if this is only related to changes in Sanic 19.6.3, but if no proxy exists, request.remote_addr will fail.

Fix checks if attr is set, otherwise uses request.ip